### PR TITLE
Not enough storage in ArchiveRoot 

### DIFF
--- a/Elasticsearch-Azure-PAAS/ServiceDefinition.csdef
+++ b/Elasticsearch-Azure-PAAS/ServiceDefinition.csdef
@@ -5,7 +5,7 @@
       <InternalEndpoint name="elasticsearch" protocol="tcp" port="9300" />
     </Endpoints>
     <LocalResources>
-      <LocalStorage name="ArchiveRoot" sizeInMB="100" cleanOnRoleRecycle="false" />
+      <LocalStorage name="ArchiveRoot" sizeInMB="300" cleanOnRoleRecycle="false" />
       <LocalStorage name="LogRoot" sizeInMB="1000" cleanOnRoleRecycle="false" />
       <LocalStorage name="ElasticRoot" sizeInMB="1000" cleanOnRoleRecycle="true" />
       <LocalStorage name="EmulatorDataRoot" sizeInMB="10000" cleanOnRoleRecycle="false" />


### PR DESCRIPTION
Not enough storage in ArchiveRoot to download Java and Elastic Search. Increased from 100 mb to 300mb
